### PR TITLE
list_string に lowercase を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [ADD] `#kvc_list_string{}` に lowercase を追加する
+  
+  - true にすると lowercase で返す
+  - @voluntas
+
+## 2024.1.0
+
 - [ADD] `,` 区切りの文字列リストを読み込める `#kvc_list_string{}` を追加
   - @voluntas
 - [UPDATE] rebar3 を 3.23.0 に上げる

--- a/include/kvconf.hrl
+++ b/include/kvconf.hrl
@@ -8,7 +8,9 @@
 
 -record(kvc_string, {}).
 
--record(kvc_list_string, {}).
+-record(kvc_list_string, {
+          lowercase = false :: boolean()
+         }).
 
 -record(kvc_integer, {
           min :: integer(),

--- a/src/kvconf_validate.erl
+++ b/src/kvconf_validate.erl
@@ -64,8 +64,8 @@ validate_type(#kvc_list_atom{}, Value) ->
     validate_list_atom(Value);
 validate_type(#kvc_string{}, Value) ->
     validate_string(Value);
-validate_type(#kvc_list_string{}, Value) ->
-    validate_list_string(Value);
+validate_type(#kvc_list_string{lowercase = Lowercase}, Value) ->
+    validate_list_string(Value, Lowercase);
 validate_type(#kvc_integer{min = Min, max = Max}, Value) ->
     validate_integer(Value, Min, Max);
 validate_type(#kvc_float{min = Min, max = Max}, Value) ->
@@ -291,14 +291,16 @@ validate_string(_Value) ->
     invalid_value.
 
 
-validate_list_string(Value) when is_binary(Value) ->
+validate_list_string(Value, true) when is_binary(Value) ->
+    validate_list_string(list_to_binary(string:to_lower(binary_to_list(Value))), false);
+validate_list_string(Value, false) when is_binary(Value) ->
     case binary:split(Value, [<<",">>, <<$\s>>], [trim_all, global]) of
         [] ->
             {ok, []};
         Values ->
             {ok, Values}
     end;
-validate_list_string(_Values) ->
+validate_list_string(_Values, _Lowercase) ->
     invalid_value.
 
 
@@ -627,18 +629,21 @@ validate_one_test() ->
 
 validate_list_string_test() ->
     ?assertEqual({ok, [~"x-abc-efg", ~"x-y-z"]},
-                 validate_list_string(~"x-abc-efg, x-y-z")),
+                 validate_list_string(~"X-ABC-EFG, X-Y-Z", true)),
+
+    ?assertEqual({ok, [~"x-abc-efg", ~"x-y-z"]},
+                 validate_list_string(~"x-abc-efg, x-y-z", false)),
     ?assertEqual({ok, []},
-                 validate_list_string(~",,,")),
+                 validate_list_string(~",,,", false)),
     ?assertEqual({ok, []},
-                 validate_list_string(~"")),
+                 validate_list_string(~"", false)),
     ?assertEqual({ok, [~"a", ~"b"]},
-                 validate_list_string(~"a,                    , , b")),
+                 validate_list_string(~"a,                    , , b", false)),
     ?assertEqual({ok, [~"a", ~"b"]},
-                 validate_list_string(~"           a,                    , , b                  ")),
+                 validate_list_string(~"           a,                    , , b                  ", false)),
 
     ?assertEqual(invalid_value,
-                 validate_list_string(1)),
+                 validate_list_string(1, false)),
 
     ok.
 


### PR DESCRIPTION
This pull request primarily focuses on the addition of a `lowercase` option to the `#kvc_list_string{}` record in the `kvconf` Erlang library. This option, when set to `true`, will return the list of strings in lowercase. The changes also involve updates to the related validation functions and tests to handle the new `lowercase` option.

Key changes include:

Updates to Record Definitions:
* [`include/kvconf.hrl`](diffhunk://#diff-5aebdad8215782bb8e5ec5f745d65377677f206db005b9237d7866c6f1913fa2L11-R13): The `#kvc_list_string{}` record has been updated to include a `lowercase` field, which is a boolean that defaults to `false`.

Validation Function Changes:
* [`src/kvconf_validate.erl`](diffhunk://#diff-5155fe8223a6afba08e5a7b4146bdab580402ad07ec56cc6f1fbe3a10f4026e3L67-R68): The `validate_type` function for `#kvc_list_string{}` now accepts the `lowercase` option.
* [`src/kvconf_validate.erl`](diffhunk://#diff-5155fe8223a6afba08e5a7b4146bdab580402ad07ec56cc6f1fbe3a10f4026e3L294-R303): The `validate_list_string` function has been updated to convert the binary value to lowercase if the `lowercase` option is `true`.

Test Updates:
* [`src/kvconf_validate.erl`](diffhunk://#diff-5155fe8223a6afba08e5a7b4146bdab580402ad07ec56cc6f1fbe3a10f4026e3L630-R646): The `validate_list_string_test` function has been updated to test both lowercase and non-lowercase scenarios for the `validate_list_string` function.

Documentation:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R20): Documented the addition of the `lowercase` option to the `#kvc_list_string{}` record.